### PR TITLE
Trajectory Velocity function now accepts a floor value for `agedays`.

### DIFF
--- a/man/get_traj_velocity.Rd
+++ b/man/get_traj_velocity.Rd
@@ -4,8 +4,8 @@
 \alias{get_traj_velocity}
 \title{Returns the veclocity of growth trajectories for _all_ subjects}
 \usage{
-get_traj_velocity(all_traj, z_score = TRUE, avg_over_days = 365L,
-  FUN = mean_na_rm_generator())
+get_traj_velocity(all_traj, z_score = TRUE, agedays_floor = 0,
+  agedays_limit = 365, FUN = mean_na_rm_generator())
 }
 \arguments{
 \item{all_traj}{Trajectory object returned from \code{\link{fit_all_trajectories}}.
@@ -14,8 +14,25 @@ Assumes all required data are present.}
 \item{z_score}{Boolean indicating whether 'y_var' parameter was for
 z-score data or not. Default is TRUE.}
 
-\item{avg_over_days}{Number of days to averge the derivative (aka velocity)
-Default is 365.}
+\item{agedays_floor}{Numeric, indicating the _floor_ (or start of range) of
+the number of `agedays` (inclusive) associated with the derivative of the
+trajectories, to which the function in `FUN` argument should apply to.
+Default is 0.
+Note, this parameter depends on the
+the number of grid points used to generate the trajectories, which
+is specified by the \code{xg} parameter for the functions
+\code{\link{hbgd::fit_trajectory}} and
+\code{\link{hbgd::fit_all_trajectories}}.}
+
+\item{agedays_limit}{Numeric, indicating the _ceiling_ (or end of range) of
+the number of `agedays` (inclusive) associated with the derivative of the
+trajectories, to which the function in `FUN` argument should apply to.
+Default is 365.
+Note, this parameter depends on the
+the number of grid points used to generate the trajectories, which
+is specified by the \code{xg} parameter for the functions
+\code{\link{hbgd::fit_trajectory}} and
+\code{\link{hbgd::fit_all_trajectories}}.}
 
 \item{FUN}{A function that will be applied to the first derivative of
 the fitted growth trajectory. This function should accept a single

--- a/tests/testthat/test_get_avg_velocity.R
+++ b/tests/testthat/test_get_avg_velocity.R
@@ -1,4 +1,5 @@
 library(tibble)
+# library(brokenstick)
 
 calc_dy <- function(x_vec, y_vec) {
   dy_vec <- rep(NA, times = length(y_vec))
@@ -16,6 +17,37 @@ package_test_data <- function(age_days, y_vec, dy_vec) {
     fit = list(list(fitgrid = fitgrid))
   )
   return(test_data_tibble)
+}
+
+#' Corrects SMOCC dataset from \link{\code{brokenstick}} package into
+#' \link{\code{hbgd}} format.
+#'
+bstick_smocc_to_hbgd <- function(data) {
+  # Rename 'id' column to 'subjid'
+  colnames(data)[colnames(data) == "id"] <- "subjid"
+  # Rename 'age' column to 'agedays'
+  colnames(data)[colnames(data) == "age"] <- "agedays"
+  # Rename 'hgt' column to 'htcm'
+  colnames(data)[colnames(data) == "hgt"] <- "htcm"
+  # Rename 'wgt' column to 'wtkg'
+  colnames(data)[colnames(data) == "wgt"] <- "wtkg"
+  # Rename 'hgt.z' column to 'haz'
+  colnames(data)[colnames(data) == "hgt.z"] <- "haz"
+
+
+  # Change the 'sex' column from factors to characters.
+  sex_col <- as.character(data$sex)
+  # Change the case of letters in the 'sex' column
+  sex_col <- replace(sex_col, sex_col == "female", "Female")
+  sex_col <- replace(sex_col, sex_col == "male", "Male")
+  data$sex <- sex_col
+
+  # Remove observations where the 'sex' variable is not recorded
+  data <- data[data$sex != "", ]
+  # Remove observations where the 'sex' variable is NA
+  data <- data[!is.na(data$sex), ]
+
+  return(data)
 }
 
 # x values generator functions -------------------------------------------------
@@ -67,6 +99,18 @@ mean_na_rm <- mean_na_rm_generator()
 
 # test cases -------------------------------------------------------------------
 
+test_that("number of subjects are the same", {
+  smc <- get_smocc_data()[1:1000,]
+  wandfit <- get_fit(smc, y_var = "haz", method = "wand")
+  smc_tr <- hbgd::fit_all_trajectories(data, mod_fit)
+  avg_velocity <- get_traj_velocity(smc_tr, z_score = TRUE)
+
+  expected_subjids <- as.integer(as.character(smc$subjid))
+  expected_n_subjs <- length(unique(expected_subjids))
+  testthat::expect_equal(expected_n_subjs, expected_subjids,
+                         label = "same number of subjects")
+})
+
 test_that("mean of non-z velocity is constant", {
   age_days <- gen_agedays()
   y_vals <- gen_linear_y_data(age_days)
@@ -92,3 +136,85 @@ test_that("mean of non-z velocity for sawtooth growth is zero", {
                          label = "zero mean velocity")
 })
 
+# test cases from bugs and feedbacks -------------------------------------------
+
+test_that("growth trajectory is the same for the old SMOCC data", {
+  # smocc_hbgd_data <- bstick_smocc_to_hbgd(brokenstick::smocc.hgtwgt)
+
+  smocc_hbgd_data <- hbgd::get_smocc_data()
+
+  wandfit <- hbgd::get_fit(smocc_hbgd_data, y_var = "haz", method = "wand")
+  smc_tr <- hbgd::fit_all_trajectories(
+    smocc_hbgd_data, wandfit, xg = seq(0,366, length = 367))
+
+  avg_velocity <- get_traj_velocity(smc_tr, z_score = TRUE)
+
+  # What we expect the first ten average velocities to be.
+  # Obtained using the older version of `hbgd` that used `datadr`
+  expected_velocities <- c(-0.0027878588, -0.0011913612,
+                           -0.0018604061, -0.0012806619,
+                            0.0025456199, -0.0005153804,
+                           -0.0006043548, -0.0018132654,
+                           -0.0038489583, -0.0008184987)
+
+  # Using inclusive, `agedays_limit` - new behaviour.
+  expected_velocities_lte <- c(-0.0027821509, -0.0011898129,
+                               -0.0018618052, -0.0012824167,
+                               0.0025471120,  -0.0005118098,
+                               -0.0006063080, -0.0018079078,
+                               -0.0038443618, -0.0008151201)
+
+  # Extracts the first 10.
+  actual_velocities <- avg_velocity[c(1:10), ]$avgder
+
+  testthat::expect_equal(actual_velocities,
+                         expected_velocities_lte,
+                         tolerance = 5e-2,
+                         label = "comparing first ten velocities.")
+})
+
+test_that("the range of growth trajectories are extracted correctly", {
+
+  AGEDAYS_FLOOR <- 10.00
+  AGEDAYS_LIMIT <- 30.00
+
+  TEST_SUBJID_SMOCC <- 10001L
+
+  smocc_hbgd_data <- hbgd::get_smocc_data()
+
+  wandfit <- hbgd::get_fit(smocc_hbgd_data, y_var = "haz", method = "wand")
+  smc_tr <- hbgd::fit_all_trajectories(
+    smocc_hbgd_data, wandfit, xg = seq(0,366, length = 367))
+
+  test_subj_fitgrid <- smc_tr[
+    smc_tr$subjid == TEST_SUBJID_SMOCC, ]$fit[[1]]$fitgrid
+  filtered_fitgrid <- test_subj_fitgrid[
+    test_subj_fitgrid$x >= AGEDAYS_FLOOR & test_subj_fitgrid$x <= AGEDAYS_LIMIT,
+    c("x", "dy", "dz")
+  ]
+
+  expected_num_rows <- 4L
+  testthat::expect_equal(nrow(filtered_fitgrid), expected_num_rows,
+                         label = "checking number of rows of data within agedays range.")
+
+
+  expected_dz_mean <- mean(filtered_fitgrid$dz)
+  avg_velocity_z <- get_traj_velocity(smc_tr, z_score = TRUE,
+                                      agedays_floor = AGEDAYS_FLOOR,
+                                      agedays_limit = AGEDAYS_LIMIT)
+  actual_dz_mean <- as.numeric(
+    avg_velocity_z[avg_velocity_z$subjid == TEST_SUBJID_SMOCC, "avgder"])
+  testthat::expect_equal(actual_dz_mean, expected_dz_mean,
+                         label = "comparing mean( dz ) within agedays range.")
+
+
+  expected_dy_mean <- mean(filtered_fitgrid$dy)
+  avg_velocity <- get_traj_velocity(smc_tr, z_score = FALSE,
+                                    agedays_floor = AGEDAYS_FLOOR,
+                                    agedays_limit = AGEDAYS_LIMIT)
+  actual_dy_mean <- as.numeric(
+    avg_velocity[avg_velocity$subjid == TEST_SUBJID_SMOCC, "avgder"])
+
+  testthat::expect_equal(actual_dy_mean, expected_dy_mean,
+                         label = "comparing mean( dy ) within agedays range.")
+})

--- a/vignettes/get-traj-velocity.Rmd
+++ b/vignettes/get-traj-velocity.Rmd
@@ -53,8 +53,28 @@ print(traj_velocity)
   function. This is mandatory.
 * `z_score = TRUE` will use the z-scores, e.g., `haz`. The default
    value is `TRUE`.
-* `avg_over_days = 365` specifies the maximum `agedays` to use.
+* `agedays_floor = 0.00` specifies the minimum `agedays` to use.
+   The default value is zero.
+   This parameter, combined with `agedays_limit`, extracts the required
+   ranges of the fitted trajectory.
+   Note that times depends heavily on the the number of grid points used to
+   generate the trajectories, which is specified by the `xg` parameter for the
+   functions `hbgd::fit_trajectory` and `hbgd::fit_all_trajectories`.
+   This is because the function supplied by `FUN` will be applied to
+   derivative data with x-axis grid value _less than_ `agedays_limit`; the
+   x-axis grid values are set up by `xg` parameter of the
+   functions `hbgd::fit_trajectory` and `hbgd::fit_all_trajectories`.   
+* `agedays_limit = 365` specifies the maximum `agedays` to use.
    The default value is one year (365 days).
+   This parameter, combined with `agedays_floor`, extracts the required
+   ranges of the fitted trajectory.
+   Note that times depends heavily on the the number of grid points used to
+   generate the trajectories, which is specified by the `xg` parameter for the
+   functions `hbgd::fit_trajectory` and `hbgd::fit_all_trajectories`.
+   This is because the function supplied by `FUN` will be applied to
+   derivative data with x-axis grid value _less than_ `agedays_limit`; the
+   x-axis grid values are set up by `xg` parameter of the
+   functions `hbgd::fit_trajectory` and `hbgd::fit_all_trajectories`.
 * `FUN` argument takes a function specified by the user that will
   be apply on the growth trajectory data. This function should only
   receive one argument, a vector containing the first derivative


### PR DESCRIPTION
Filtering of trajectory is based on `inclusive` values (i.e., >= floor,
and <= ceiling). In contrast, the old `hbgd` that used `datadr` used
exclusive filter (i.e., < ceiling).
Renamed the argument names to be more meaningful (e.g.,
`agedays_limit` as opposed to `avg_over_days`.)
New test case to test filtering based on floor and ceiling `agedays`.
New test case that compares result from old `hbgd` package; however,
since the range extraction criterion have shifted to using inclusive
agedays, more synthetic data may be needed later to augment the current
tests.